### PR TITLE
Updated to v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ Changelog
 ---------
 <!--(CHANGELOG_TOP)-->
 **1.3.1**
-* Fixed iOS and Android Flutter method channel calls for void-returning SDK methods so returned Futures complete.
-* Added tests covering Dart method channel forwarding and native void method reply coverage.
-* Fixed the bundled example path dependency name to match the package name.
+* Updated iOS SDK to 5.0.1 (GA-SDK-IOS)
+* Updated Android SDK to 7.0.1 (gameanalytics-android)
+* Fixed iOS and Android Flutter method channel calls for void-returning SDK methods so returned Futures complete
+* Added tests covering Dart method channel forwarding and native void method reply coverage
 
 **1.3.0**
 * Updated iOS SDK to 5.0.0 (GA-SDK-IOS)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.gameanalytics.sdk:gameanalytics-android:7.0.0'
+    implementation 'com.gameanalytics.sdk:gameanalytics-android:7.0.1'
     implementation 'com.google.android.gms:play-services-appset:16.0.2'
 }

--- a/ios/gameanalytics_sdk.podspec
+++ b/ios/gameanalytics_sdk.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*.{h,m,}'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'GA-SDK-IOS', '5.0.0'
+  s.dependency 'GA-SDK-IOS', '5.0.1'
   s.platform = :ios, '9.0'
 
   s.static_framework = true


### PR DESCRIPTION
- Updated Android SDK to 7.0.1 (gameanalytics-android)
- Updated iOS SDK to 5.0.1 (GA-SDK-IOS)
- Fixed iOS and Android Flutter method channel replies for void-returning SDK methods so returned Futures complete
- Added tests covering Dart method channel forwarding and native void method reply coverage